### PR TITLE
FIX: issue in context of hidden user's profile

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -138,6 +138,12 @@
         var options = fieldOptions[name]
         const siteUserFields = component.site.get('user_fields')
         const userFields = component.get(model_name  + '.user_fields')
+
+        // User's profile is hidden
+        if (userFields === undefined) {
+            return
+        }
+
         component.set(name, options.map(field => {
             var base = field.link.base || ''
             var baseregex = field.link.baseregex || ''


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/broken-layout-on-users-hidden-profile-page/282648

If the user's public profile is hidden, there are no user fields provided.
